### PR TITLE
chore(pre-align): align heading structure (public-api-compat.md) with ko

### DIFF
--- a/en/public-api-compat.md
+++ b/en/public-api-compat.md
@@ -1,4 +1,7 @@
-## Network > VPC > Openstack Compatible API Guide
+<!-- pre-align:aligned sig=bfcd6718aae8 -->
+
+<a id="network-vpc-openstack-compatible-api-guide"></a>
+## Network > VPC > Openstack Compatible API Guide { #network-vpc-openstack-compatible-api-guide }
 
 NHN Cloud Network services provide APIs compatible with OpenStack neutron APIs.
 The OpenStack-compatible APIs are provided as follows.
@@ -23,14 +26,17 @@ For Openstack compatible APIs, the `network` type endpoint is used. For more det
 | network | Korea (Pangyo) Region<br>Korea (Pyeongchon) Region<br>Korea (Gwangju) Region<br>Japan (Tokyo) Region | https://kr1-api-network-infrastructure.nhncloudservice.com<br>https://kr2-api-network-infrastructure.nhncloudservice.com<br>https://kr3-api-network-infrastructure.nhncloudservice.com<br>https://jp1-api-network-infrastructure.nhncloudservice.com |
 
 
-## Network
-### List Networks
+<a id="network"></a>
+## Network { #network }
+<a id="list-networks"></a>
+### List Networks { #list-networks }
 Returns the list of available networks.
 ```
 GET /v2.0/networks
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-networks-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -47,6 +53,7 @@ This API does not require a request body.
 | sort_key | Query | String | - | Sorting key of network to query<br>Sort in the direction as specified by `sort_dir` |
 | fields | Query | String | - | Field name of network to query<br>e.g., `fields=id&fields=name` |
 
+<a id="list-networks-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -108,14 +115,17 @@ This API does not require a request body.
 
 ---
 
-## Subnet
-### List Subnets
+<a id="subnet"></a>
+## Subnet { #subnet }
+<a id="list-subnets"></a>
+### List Subnets { #list-subnets }
 Returns the list of available subnets.
 ```
 GET /v2.0/subnets
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-subnets-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -132,6 +142,7 @@ This API does not require a request body.
 | sort_key | Query | String | - | Sorting key of subnet to query<br>Sort in the direction as specified by `sort_dir` |
 | fields | Query | String | - | Field name of subnet to query<br>e.g., `fields=id&fields=name` |
 
+<a id="list-subnets-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -193,14 +204,17 @@ This API does not require a request body.
 
 ---
 
-## Port
-### List Ports
+<a id="port"></a>
+## Port { #port }
+<a id="list-ports"></a>
+### List Ports { #list-ports }
 Return the list of ports.
 ```
 GET /v2.0/ports
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-ports-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -219,6 +233,7 @@ This API does not require a request body.
 | device_id | Query | UUID | - | Resource ID for the port to query |
 | fields | Query | String | - | Field name of port to query<br>e.g.) `fields=id&fields=name` |
 
+<a id="list-ports-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -280,13 +295,15 @@ This API does not require a request body.
 
 ---
 
-### Get Port
+<a id="get-port"></a>
+### Get Port { #get-port }
 Retrieves a port.
 ```
 GET /v2.0/ports/{portId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-port-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -296,6 +313,7 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID |
 | fields | Query | String | - | Field name of port to query<br>e.g., `fields=id&fields=name` |
 
+<a id="get-port-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -355,13 +373,15 @@ This API does not require a request body.
 
 ---
 
-### Create Port
+<a id="create-port"></a>
+### Create Port { #create-port }
 Creates a new port. The created port can be used when creating an instance.
 ```
 POST /v2.0/ports
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-port-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -403,6 +423,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="create-port-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -461,13 +482,15 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Change Port
+<a id="change-port"></a>
+### Change Port { #change-port }
 Changes the properties of the specified port.
 ```
 PUT /v2.0/ports/{portId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-port-request"></a>
 #### Request
 | Name | Type | Format | Required | Description |
 |---|---|---|---|---|
@@ -506,6 +529,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="change-port-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -564,27 +588,15 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Delete a port
-
-```
-
-```
-
-#### Request
-
-
-| Name | Type | Format | Required | Description |
-|---|---|---|---|---|
-|  |  | UUID | O |  |
-| tokenId | Header | String | O | Token ID |
-
-### Delete Port
+<a id="delete-port"></a>
+### Delete Port { #delete-port }
 Deletes a specified port.
 ```
 DELETE /v2.0/ports/{portId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-port-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -593,6 +605,7 @@ This API does not require a request body.
 | portId | URL | UUID | O | Port ID |
 | tokenId | Header | String | O | Token ID |
 
+<a id="delete-port-response"></a>
 #### Response
 This API does not return a response body.
 

--- a/ja/public-api-compat.md
+++ b/ja/public-api-compat.md
@@ -1,4 +1,7 @@
-## Network > VPC > Openstack互換APIガイド
+<!-- pre-align:aligned sig=bfcd6718aae8 -->
+
+<a id="network-vpc-openstack-compatible-api-guide"></a>
+## Network > VPC > Openstack互換APIガイド { #network-vpc-openstack-compatible-api-guide }
 
 NHN Cloud NetworkサービスはOpenStack neutron APIと互換性のあるAPIを提供します。 
 提供するOpenstack互換APIは次のとおりです。
@@ -23,14 +26,17 @@ Openstack互換APIは`network`タイプエンドポイントを利用します�
 | network | 韓国(パンギョ)リージョン<br>韓国(ピョンチョン)リージョン<br>韓国(光州)リージョン<br>日本(東京)リージョン | https://kr1-api-network-infrastructure.nhncloudservice.com<br>https://kr2-api-network-infrastructure.nhncloudservice.com<br>https://kr3-api-network-infrastructure.nhncloudservice.com<br>https://jp1-api-network-infrastructure.nhncloudservice.com |
 
 
-## ネットワーク
-### ネットワークリスト表示
+<a id="network"></a>
+## ネットワーク { #network }
+<a id="list-networks"></a>
+### ネットワークリスト表示 { #list-networks }
 使用可能なネットワークリストを返します。
 ```
 GET /v2.0/networks
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-networks-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -47,6 +53,7 @@ X-Auth-Token: {tokenId}
 | sort_key | Query | String | - | 照会するネットワークのソートキー<br>`sort_dir`で指定した方向通りにソート |
 | fields | Query | String | - | 照会するネットワークのフィールド名<br>例: `fields=id&fields=name` |
 
+<a id="list-networks-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -108,14 +115,17 @@ X-Auth-Token: {tokenId}
 
 ---
 
-## サブネット
-### サブネットリスト表示
+<a id="subnet"></a>
+## サブネット { #subnet }
+<a id="list-subnets"></a>
+### サブネットリスト表示 { #list-subnets }
 使用可能なサブネットリストを返します。
 ```
 GET /v2.0/subnets
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-subnets-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -132,6 +142,7 @@ X-Auth-Token: {tokenId}
 | sort_key | Query | String | - | 照会するサブネットのソートキー<br>`sort_dir`で指定した方向通りにソート |
 | fields | Query | String | - | 照会するサブネットのフィールド名<br>例: `fields=id&fields=name` |
 
+<a id="list-subnets-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -193,14 +204,17 @@ X-Auth-Token: {tokenId}
 
 ---
 
-## ポート
-### ポートリスト表示
+<a id="port"></a>
+## ポート { #port }
+<a id="list-ports"></a>
+### ポートリスト表示 { #list-ports }
 ポートリストを返します。
 ```
 GET /v2.0/ports
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-ports-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -219,6 +233,7 @@ X-Auth-Token: {tokenId}
 | device_id | Query | UUID | - | 照会するポートを使用するリソースID |
 | fields | Query | String | - | 照会するポートのフィールド名<br>例: `fields=id&fields=name` |
 
+<a id="list-ports-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -281,13 +296,15 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ポート表示
+<a id="get-port"></a>
+### ポート表示 { #get-port }
 ポートを照会します。
 ```
 GET /v2.0/ports/{portId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-port-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -297,6 +314,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID |
 | fields | Query | String | - | 照会するポートのフィールド名<br>例: `fields=id&fields=name` |
 
+<a id="get-port-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -358,13 +376,15 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ポートを作成する
+<a id="create-port"></a>
+### ポートを作成する { #create-port }
 新しいポートを作成します。作成したポートはインスタンス作成時に活用できます。
 ```
 POST /v2.0/ports
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-port-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -407,6 +427,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="create-port-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -464,13 +485,15 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ポートを変更する
+<a id="change-port"></a>
+### ポートを変更する { #change-port }
 指定したポートのプロパティを変更します。
 ```
 PUT /v2.0/ports/{portId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-port-request"></a>
 #### リクエスト
 | 名前 | 種類 | 形式 | 必須 | 説明 |
 |---|---|---|---|---|
@@ -509,6 +532,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="change-port-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -567,13 +591,15 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ポートを削除する
+<a id="delete-port"></a>
+### ポートを削除する { #delete-port }
 指定したポートを削除します。
 ```
 DELETE /v2.0/ports/{portId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-port-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -582,6 +608,7 @@ X-Auth-Token: {tokenId}
 | portId | URL | UUID | O | ポートID |
 | tokenId | Header | String | O | トークンID |
 
+<a id="delete-port-response"></a>
 #### レスポンス
 このAPIはレスポンス本文を返しません。
 

--- a/ko/public-api-compat.md
+++ b/ko/public-api-compat.md
@@ -1,4 +1,7 @@
-## Network > VPC > OpenStack 호환 API 가이드
+<!-- pre-align:aligned sig=bfcd6718aae8 -->
+
+<a id="network-vpc-openstack-compatible-api-guide"></a>
+## Network > VPC > OpenStack 호환 API 가이드 { #network-vpc-openstack-compatible-api-guide }
 
 NHN Cloud Network 서비스는 OpenStack neutron API와 호환되는 API를 제공합니다.
 제공하는 OpenStack 호환 API는 다음과 같습니다.
@@ -23,14 +26,17 @@ OpenStack 호환 API는 `network` 타입 엔드포인트를 이용합니다. 정
 | network | 한국(판교) 리전<br>한국(평촌) 리전<br>한국(광주) 리전<br>일본(도쿄) 리전 | https://kr1-api-network-infrastructure.nhncloudservice.com<br>https://kr2-api-network-infrastructure.nhncloudservice.com<br>https://kr3-api-network-infrastructure.nhncloudservice.com<br>https://jp1-api-network-infrastructure.nhncloudservice.com |
 
 
-## 네트워크
-### 네트워크 목록 보기
+<a id="network"></a>
+## 네트워크 { #network }
+<a id="list-networks"></a>
+### 네트워크 목록 보기 { #list-networks }
 사용 가능한 네트워크 목록을 반환합니다.
 ```
 GET /v2.0/networks
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-networks-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -47,6 +53,7 @@ X-Auth-Token: {tokenId}
 | sort_key | Query | String | - | 조회할 네트워크의 정렬 키<br>`sort_dir`에서 지정한 방향대로 정렬 |
 | fields | Query | String | - | 조회할 네트워크의 필드 이름<br>예: `fields=id&fields=name` |
 
+<a id="list-networks-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -108,14 +115,17 @@ X-Auth-Token: {tokenId}
 
 ---
 
-## 서브넷
-### 서브넷 목록 보기
+<a id="subnet"></a>
+## 서브넷 { #subnet }
+<a id="list-subnets"></a>
+### 서브넷 목록 보기 { #list-subnets }
 사용 가능한 서브넷 목록을 반환합니다.
 ```
 GET /v2.0/subnets
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-subnets-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -132,6 +142,7 @@ X-Auth-Token: {tokenId}
 | sort_key | Query | String | - | 조회할 서브넷의 정렬 키<br>`sort_dir`에서 지정한 방향대로 정렬 |
 | fields | Query | String | - | 조회할 서브넷의 필드 이름<br>예: `fields=id&fields=name` |
 
+<a id="list-subnets-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -193,14 +204,17 @@ X-Auth-Token: {tokenId}
 
 ---
 
-## 포트
-### 포트 목록 보기
+<a id="port"></a>
+## 포트 { #port }
+<a id="list-ports"></a>
+### 포트 목록 보기 { #list-ports }
 포트 목록을 반환합니다.
 ```
 GET /v2.0/ports
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-ports-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -219,6 +233,7 @@ X-Auth-Token: {tokenId}
 | device_id | Query | UUID | - | 조회할 포트를 사용하는 리소스 ID |
 | fields | Query | String | - | 조회할 포트의 필드 이름<br>예: `fields=id&fields=name` |
 
+<a id="list-ports-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -281,13 +296,15 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 포트 보기
+<a id="get-port"></a>
+### 포트 보기 { #get-port }
 포트를 조회합니다.
 ```
 GET /v2.0/ports/{portId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-port-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -297,6 +314,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | fields | Query | String | - | 조회할 포트의 필드 이름<br>예: `fields=id&fields=name` |
 
+<a id="get-port-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -358,13 +376,15 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 포트 생성하기
+<a id="create-port"></a>
+### 포트 생성하기 { #create-port }
 새로운 포트를 생성합니다. 생성한 포트는 인스턴스 생성 시 활용할 수 있습니다.
 ```
 POST /v2.0/ports
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-port-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -407,6 +427,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="create-port-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -464,13 +485,15 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 포트 변경하기
+<a id="change-port"></a>
+### 포트 변경하기 { #change-port }
 지정한 포트의 속성을 변경합니다.
 ```
 PUT /v2.0/ports/{portId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-port-request"></a>
 #### 요청
 | 이름 | 종류 | 형식 | 필수 | 설명 |
 |---|---|---|---|---|
@@ -509,6 +532,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="change-port-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -567,13 +591,15 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 포트 삭제하기
+<a id="delete-port"></a>
+### 포트 삭제하기 { #delete-port }
 지정한 포트를 삭제합니다.
 ```
 DELETE /v2.0/ports/{portId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-port-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -582,6 +608,7 @@ X-Auth-Token: {tokenId}
 | portId | URL | UUID | O | 포트 ID |
 | tokenId | Header | String | O | 토큰 ID |
 
+<a id="delete-port-response"></a>
 #### 응답
 이 API는 응답 본문을 반환하지 않습니다.
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 1 doc(s) scanned · 3 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/PR-145/6/ |
| Generated | 2026-07-11T13:30:50 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork-VPC%2Fblob%2Falpha%2Fko%2Fpublic-api-compat.md&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork-VPC%2Fpull%2F57&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork-VPC%2Fpull%2F57&ref=alpha&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | pruned | marker | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | --: | :--: | :--: |
| `ko/public-api-compat.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/public-api-compat.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 1 | ✅ | ✅ |
| `ja/public-api-compat.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Network-VPC`